### PR TITLE
✨ Add .env formatter CLI support

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -2,11 +2,32 @@
 
 const path = require('path');
 const { scanProjectForEnvUsage } = require('../src/scanner');
+const { formatEnvFile } = require('../src/format');
 
-// Parse CLI args
 const args = process.argv.slice(2);
-let envFile = '.env'; // default
 
+const command = args[0]; // e.g., "format" or undefined
+
+if (command === 'format') {
+  const inputFile = args[1] || '.env'; // default file
+  const options = {
+    inputFile,
+    fix: args.includes('--fix'),
+    sort: args.includes('--sort'),
+  };
+
+  // Check for --output <filename>
+  const outputIndex = args.indexOf('--output');
+  if (outputIndex !== -1 && args[outputIndex + 1]) {
+    options.outputFile = args[outputIndex + 1];
+  }
+
+  formatEnvFile(options);
+  process.exit(0); // Exit after format
+}
+
+// Default behavior: run scanner
+let envFile = '.env';
 args.forEach((arg) => {
   if (arg.startsWith('--env-file=')) {
     envFile = arg.split('=')[1];
@@ -14,7 +35,7 @@ args.forEach((arg) => {
 });
 
 (async () => {
-  const targetDir = process.cwd(); // directory where the CLI is run
+  const targetDir = process.cwd();
   console.log(`🔍 Running envAudit on: ${targetDir}`);
   console.log(`📄 Using env file: ${envFile}\n`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,22 @@
 {
-  "name": "envaudit",
+  "name": "envlens",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "envaudit",
+      "name": "envlens",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.4.5",
-        "fast-glob": "^3.3.2"
+        "dotenv": "^16.0.0",
+        "fast-glob": "^3.3.1"
       },
       "bin": {
         "envaudit": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envlens",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Audit your Node.js project's environment variables for missing or unused keys.",
   "main": "index.js",
   "bin": {

--- a/src/format.js
+++ b/src/format.js
@@ -1,0 +1,101 @@
+const fs = require('fs');
+const path = require('path');
+
+function needsQuoting(value) {
+  return /\s|#|=|["']/.test(value);
+}
+
+function quote(value) {
+  const escaped = value.replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function formatEnvFile({ inputFile, outputFile, fix = false, sort = false }) {
+  try {
+    const inputPath = path.resolve(process.cwd(), inputFile);
+    if (!fs.existsSync(inputPath)) {
+      console.error(`❌ File not found: ${inputFile}`);
+      return;
+    }
+
+    const lines = fs.readFileSync(inputPath, 'utf-8').split(/\r?\n/);
+    const seenKeys = new Set();
+    const formattedLines = [];
+
+    for (let idx = 0; idx < lines.length; idx++) {
+      const line = lines[idx];
+
+      const trimmed = line.trim();
+
+      if (trimmed === '') {
+        formattedLines.push(''); // preserve blank line
+        continue;
+      }
+
+      if (trimmed.startsWith('#')) {
+        formattedLines.push(line); // preserve full comment line
+        continue;
+      }
+
+      const eqIndex = line.indexOf('=');
+      if (eqIndex === -1) {
+        console.warn(`⚠️ Line ${idx + 1} is malformed: ${line}`);
+        continue;
+      }
+
+      let key = line.slice(0, eqIndex).trim();
+      let value = line.slice(eqIndex + 1).trim();
+
+      if (!key || key === '=' || key.includes(' ')) {
+        console.warn(`⚠️ Invalid key at line ${idx + 1}: "${key}"`);
+        continue;
+      }
+
+      if (seenKeys.has(key)) {
+        console.warn(`⚠️ Duplicate key at line ${idx + 1}: "${key}" — skipping`);
+        continue;
+      }
+
+      seenKeys.add(key);
+
+      if (value === '') {
+        // leave empty value as-is
+      } else if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        // already quoted, leave as-is
+      } else if (needsQuoting(value)) {
+        value = quote(value);
+      }
+
+      formattedLines.push(`${key}=${value}`);
+    }
+
+    const finalLines = sort
+      ? [...formattedLines].sort((a, b) => {
+          // keep comments and empty lines in place
+          if (a.startsWith('#') || a === '') return -1;
+          if (b.startsWith('#') || b === '') return 1;
+          return a.localeCompare(b);
+        })
+      : formattedLines;
+
+    const output = finalLines.join('\n') + '\n';
+
+    if (outputFile) {
+      fs.writeFileSync(path.resolve(process.cwd(), outputFile), output, 'utf-8');
+      console.log(`✅ Formatted .env saved to: ${outputFile}`);
+    } else if (fix) {
+      fs.writeFileSync(inputPath, output, 'utf-8');
+      console.log(`✅ .env formatted and overwritten.`);
+    } else {
+      console.log('🧼 Formatted .env output:\n');
+      console.log(output);
+    }
+  } catch (err) {
+    console.error('[envAudit:format] Error:', err.message);
+  }
+}
+
+module.exports = { formatEnvFile };


### PR DESCRIPTION
✨ Feature: .env Formatter Support Added
✅ What's New
This PR adds a built-in .env formatting utility to the envlens package. It helps developers clean, quote, and optionally sort their .env files. The formatter can:

Trim unnecessary spaces

Quote values containing spaces, special characters, or =

Skip malformed lines

Optionally sort keys

Fix and overwrite the original file if desired

🧪 Test Cases Covered
Proper quoting of values with spaces, special characters, and inline comments

Handling of malformed lines, duplicates, and empty keys

Preserving existing quotes

Sorting behavior (optional)

UTF-8, boolean, and numeric values

Keys with extra spaces or tabs

Escape handling (\n, \\, etc.)